### PR TITLE
Feature/te 8265 add a foreign flag

### DIFF
--- a/src/SprykerSdk/Shared/ComposerConstrainer/ComposerConstrainerConstants.php
+++ b/src/SprykerSdk/Shared/ComposerConstrainer/ComposerConstrainerConstants.php
@@ -21,4 +21,14 @@ interface ComposerConstrainerConstants
      * @api
      */
     public const CORE_NAMESPACES = 'CORE_NAMESPACES';
+
+    /**
+     * Specification:
+     * - Returns a list of configured project namespaces which are used to separate vendor namespaces from projects.
+     *
+     * @uses \Spryker\Shared\Kernel\KernelConstants::PROJECT_NAMESPACES
+     *
+     * @api
+     */
+    public const PROJECT_NAMESPACES = 'PROJECT_NAMESPACES';
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
@@ -41,6 +41,6 @@ class ComposerJsonReader implements ComposerJsonReaderInterface
      */
     public function readFromFilePath(string $filePath): array
     {
-        return json_decode(file_get_contents($path . static::COMPOSER_JSON_FILENAME), true);
+        return json_decode(file_get_contents($filePath . static::COMPOSER_JSON_FILENAME), true);
     }
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
@@ -31,11 +31,11 @@ class ComposerJsonReader implements ComposerJsonReaderInterface
      */
     public function read(): array
     {
-        return $this->readFromPath($this->config->getProjectRootPath());
+        return $this->readFromFilePath($this->config->getProjectRootPath());
     }
 
     /**
-     * @param string $path
+     * @param string $filePath
      *
      * @return array
      */

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
@@ -43,7 +43,6 @@ class ComposerJsonReader implements ComposerJsonReaderInterface
     {
         $composerJsonFileName = $filePath . static::COMPOSER_JSON_FILENAME;
         if (!file_exists($composerJsonFileName)) {
-
             return [];
         }
 

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
@@ -11,6 +11,8 @@ use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
 
 class ComposerJsonReader implements ComposerJsonReaderInterface
 {
+    public const COMPOSER_JSON_FILENAME = 'composer.json';
+
     /**
      * @var \SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig
      */
@@ -29,6 +31,16 @@ class ComposerJsonReader implements ComposerJsonReaderInterface
      */
     public function read(): array
     {
-        return json_decode(file_get_contents($this->config->getProjectRootPath() . 'composer.json'), true);
+        return $this->readFromPath($this->config->getProjectRootPath());
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return array
+     */
+    public function readFromFilePath(string $filePath): array
+    {
+        return json_decode(file_get_contents($path . static::COMPOSER_JSON_FILENAME), true);
     }
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
@@ -11,7 +11,7 @@ use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
 
 class ComposerJsonReader implements ComposerJsonReaderInterface
 {
-    public const COMPOSER_JSON_FILENAME = 'composer.json';
+    protected const COMPOSER_JSON_FILENAME = 'composer.json';
 
     /**
      * @var \SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig
@@ -41,6 +41,12 @@ class ComposerJsonReader implements ComposerJsonReaderInterface
      */
     public function readFromFilePath(string $filePath): array
     {
-        return json_decode(file_get_contents($filePath . static::COMPOSER_JSON_FILENAME), true);
+        $composerJsonFileName = $filePath . static::COMPOSER_JSON_FILENAME;
+        if (!file_exists($composerJsonFileName)) {
+
+            return [];
+        }
+
+        return json_decode(file_get_contents($composerJsonFileName), true);
     }
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReaderInterface.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReaderInterface.php
@@ -13,4 +13,11 @@ interface ComposerJsonReaderInterface
      * @return array
      */
     public function read(): array;
+
+    /**
+     * @param string $path
+     *
+     * @return array
+     */
+    public function readFromFilePath(string $filePath): array;
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReaderInterface.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReaderInterface.php
@@ -15,7 +15,7 @@ interface ComposerJsonReaderInterface
     public function read(): array;
 
     /**
-     * @param string $path
+     * @param string $filePath
      *
      * @return array
      */

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
@@ -41,6 +41,18 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
+     * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Updater\ConstraintUpdaterInterface
+     */
+    public function createCoreAndForeignConstraintUpdater(): ConstraintUpdaterInterface
+    {
+        return new ConstraintUpdater(
+            $this->createCoreAndForeignConstraintValidator(),
+            $this->createComposerJsonReader(),
+            $this->createComposerJsonWriter()
+        );
+    }
+
+    /**
      * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Validator\ConstraintValidatorInterface
      */
     public function createConstraintValidator(): ConstraintValidatorInterface
@@ -91,7 +103,6 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     {
         return [
             $this->createExtendedModuleFinder(),
-            $this->createUsedForeignModuleFinder(),
         ];
     }
 

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
@@ -15,7 +15,7 @@ use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson\ComposerJs
 use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerLock\ComposerLockReader;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerLock\ComposerLockReaderInterface;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\ExtendedModuleFinder\ExtendedModuleFinder;
-use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\ExtendedModuleFinder\UsedForeignModuleFinder;
+use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\UsedForeignModuleFinder\UsedForeignModuleFinder;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\Finder;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Updater\ConstraintUpdater;
@@ -53,6 +53,18 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
+     * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Validator\ConstraintValidatorInterface
+     */
+    public function createCoreAndForeignConstraintValidator(): ConstraintValidatorInterface
+    {
+        return new ConstraintValidator(
+            $this->createUsedCoreAndForeignModuleFinder(),
+            $this->createComposerJsonReader(),
+            $this->createComposerLockReader()
+        );
+    }
+
+    /**
      * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface
      */
     public function createUsedModuleFinder(): FinderInterface
@@ -63,12 +75,33 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
+     * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface
+     */
+    public function createUsedCoreAndForeignModuleFinder(): FinderInterface
+    {
+        return new Finder(
+            $this->getCoreAndForeignFinderStack()
+        );
+    }
+
+    /**
      * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface[]
      */
     public function getFinderStack(): array
     {
         return [
-            //TODO: $this->createExtendedModuleFinder(),
+            $this->createExtendedModuleFinder(),
+            $this->createUsedForeignModuleFinder(),
+        ];
+    }
+
+    /**
+     * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface[]
+     */
+    public function getCoreAndForeignFinderStack(): array
+    {
+        return [
+            $this->createExtendedModuleFinder(),
             $this->createUsedForeignModuleFinder(),
         ];
     }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
@@ -43,10 +43,10 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     /**
      * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Updater\ConstraintUpdaterInterface
      */
-    public function createCoreAndForeignConstraintUpdater(): ConstraintUpdaterInterface
+    public function createForeignConstraintUpdater(): ConstraintUpdaterInterface
     {
         return new ConstraintUpdater(
-            $this->createCoreAndForeignConstraintValidator(),
+            $this->createForeignConstraintValidator(),
             $this->createComposerJsonReader(),
             $this->createComposerJsonWriter()
         );
@@ -67,10 +67,10 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     /**
      * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Validator\ConstraintValidatorInterface
      */
-    public function createCoreAndForeignConstraintValidator(): ConstraintValidatorInterface
+    public function createForeignConstraintValidator(): ConstraintValidatorInterface
     {
         return new ConstraintValidator(
-            $this->createUsedCoreAndForeignModuleFinder(),
+            $this->createForeignModuleFinder(),
             $this->createComposerJsonReader(),
             $this->createComposerLockReader()
         );
@@ -89,10 +89,10 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     /**
      * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface
      */
-    public function createUsedCoreAndForeignModuleFinder(): FinderInterface
+    public function createForeignModuleFinder(): FinderInterface
     {
         return new Finder(
-            $this->getCoreAndForeignFinderStack()
+            $this->getUsedForeignFinderStack()
         );
     }
 
@@ -109,10 +109,9 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     /**
      * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface[]
      */
-    public function getCoreAndForeignFinderStack(): array
+    public function getUsedForeignFinderStack(): array
     {
         return [
-            $this->createExtendedModuleFinder(),
             $this->createUsedForeignModuleFinder(),
         ];
     }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
@@ -133,7 +133,8 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     public function createUsedForeignModuleFinder(): FinderInterface
     {
         return new UsedForeignModuleFinder(
-            $this->getConfig()
+            $this->getConfig(),
+            $this->createComposerJsonReader()
         );
     }
 

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
@@ -15,6 +15,7 @@ use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson\ComposerJs
 use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerLock\ComposerLockReader;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerLock\ComposerLockReaderInterface;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\ExtendedModuleFinder\ExtendedModuleFinder;
+use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\ExtendedModuleFinder\UsedForeignModuleFinder;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\Finder;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Updater\ConstraintUpdater;
@@ -67,7 +68,8 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     public function getFinderStack(): array
     {
         return [
-            $this->createExtendedModuleFinder(),
+            //TODO: $this->createExtendedModuleFinder(),
+            $this->createUsedForeignModuleFinder(),
         ];
     }
 
@@ -77,6 +79,16 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     public function createExtendedModuleFinder(): FinderInterface
     {
         return new ExtendedModuleFinder(
+            $this->getConfig()
+        );
+    }
+
+    /**
+     * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface
+     */
+    public function createUsedForeignModuleFinder(): FinderInterface
+    {
+        return new UsedForeignModuleFinder(
             $this->getConfig()
         );
     }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
@@ -112,7 +112,7 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     public function getCoreAndForeignFinderStack(): array
     {
         return [
-            $this->createExtendedModuleFinder(),
+            //$this->createExtendedModuleFinder(),
             $this->createUsedForeignModuleFinder(),
         ];
     }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
@@ -15,9 +15,9 @@ use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson\ComposerJs
 use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerLock\ComposerLockReader;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerLock\ComposerLockReaderInterface;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\ExtendedModuleFinder\ExtendedModuleFinder;
-use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\UsedForeignModuleFinder\UsedForeignModuleFinder;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\Finder;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface;
+use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\UsedForeignModuleFinder\UsedForeignModuleFinder;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Updater\ConstraintUpdater;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Updater\ConstraintUpdaterInterface;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Validator\ConstraintValidator;

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerBusinessFactory.php
@@ -112,7 +112,7 @@ class ComposerConstrainerBusinessFactory extends AbstractBusinessFactory
     public function getCoreAndForeignFinderStack(): array
     {
         return [
-            //$this->createExtendedModuleFinder(),
+            $this->createExtendedModuleFinder(),
             $this->createUsedForeignModuleFinder(),
         ];
     }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacade.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacade.php
@@ -34,6 +34,18 @@ class ComposerConstrainerFacade extends AbstractFacade implements ComposerConstr
      *
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
      */
+    public function updateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer
+    {
+        return $this->getFactory()->createCoreAndForeignConstraintUpdater()->updateConstraints();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
+     */
     public function validateConstraints(): ComposerConstraintCollectionTransfer
     {
         return $this->getFactory()->createConstraintValidator()->validateConstraints();

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacade.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacade.php
@@ -34,9 +34,9 @@ class ComposerConstrainerFacade extends AbstractFacade implements ComposerConstr
      *
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
      */
-    public function updateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer
+    public function updateForeignConstraints(): ComposerConstraintCollectionTransfer
     {
-        return $this->getFactory()->createCoreAndForeignConstraintUpdater()->updateConstraints();
+        return $this->getFactory()->createForeignConstraintUpdater()->updateConstraints();
     }
 
     /**
@@ -58,8 +58,8 @@ class ComposerConstrainerFacade extends AbstractFacade implements ComposerConstr
      *
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
      */
-    public function validateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer
+    public function validateForeignConstraints(): ComposerConstraintCollectionTransfer
     {
-        return $this->getFactory()->createCoreAndForeignConstraintValidator()->validateConstraints();
+        return $this->getFactory()->createForeignConstraintValidator()->validateConstraints();
     }
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacade.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacade.php
@@ -38,4 +38,16 @@ class ComposerConstrainerFacade extends AbstractFacade implements ComposerConstr
     {
         return $this->getFactory()->createConstraintValidator()->validateConstraints();
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
+     */
+    public function validateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer
+    {
+        return $this->getFactory()->createCoreAndForeignConstraintValidator()->validateConstraints();
+    }
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
@@ -24,4 +24,11 @@ interface ComposerConstrainerFacadeInterface
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
      */
     public function validateConstraints(): ComposerConstraintCollectionTransfer;
+
+    /**
+     * @api
+     *
+     * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
+     */
+    public function validateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer;
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
@@ -26,9 +26,22 @@ interface ComposerConstrainerFacadeInterface
     public function validateConstraints(): ComposerConstraintCollectionTransfer;
 
     /**
+     * Specification:
+     * - Validates core and foreign module constrains.
+     *
      * @api
      *
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
      */
     public function validateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer;
+
+    /**
+     * Specification:
+     * - Updates core and foreign module constrains.
+     *
+     * @api
+     *
+     * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
+     */
+    public function updateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer;
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
@@ -13,7 +13,7 @@ interface ComposerConstrainerFacadeInterface
 {
     /**
      * Specification:
-     * - Updates core modules constrains.
+     * - Updates core modules constraints.
      *
      * @api
      *
@@ -23,7 +23,7 @@ interface ComposerConstrainerFacadeInterface
 
     /**
      * Specification:
-     * - Validates core modules constrains.
+     * - Validates core modules constraints.
      *
      * @api
      *
@@ -33,7 +33,7 @@ interface ComposerConstrainerFacadeInterface
 
     /**
      * Specification:
-     * - Validates foreign modules constrains.
+     * - Validates foreign modules constraints.
      *
      * @api
      *
@@ -43,7 +43,7 @@ interface ComposerConstrainerFacadeInterface
 
     /**
      * Specification:
-     * - Updates foreign modules constrains.
+     * - Updates foreign modules constraints.
      *
      * @api
      *

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
@@ -33,7 +33,7 @@ interface ComposerConstrainerFacadeInterface
      *
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
      */
-    public function validateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer;
+    public function validateForeignConstraints(): ComposerConstraintCollectionTransfer;
 
     /**
      * Specification:
@@ -43,5 +43,5 @@ interface ComposerConstrainerFacadeInterface
      *
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
      */
-    public function updateCoreAndForeignConstraints(): ComposerConstraintCollectionTransfer;
+    public function updateForeignConstraints(): ComposerConstraintCollectionTransfer;
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/ComposerConstrainerFacadeInterface.php
@@ -12,6 +12,9 @@ use Generated\Shared\Transfer\ComposerConstraintCollectionTransfer;
 interface ComposerConstrainerFacadeInterface
 {
     /**
+     * Specification:
+     * - Updates core modules constrains.
+     *
      * @api
      *
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
@@ -19,6 +22,9 @@ interface ComposerConstrainerFacadeInterface
     public function updateConstraints(): ComposerConstraintCollectionTransfer;
 
     /**
+     * Specification:
+     * - Validates core modules constrains.
+     *
      * @api
      *
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
@@ -27,7 +33,7 @@ interface ComposerConstrainerFacadeInterface
 
     /**
      * Specification:
-     * - Validates core and foreign module constrains.
+     * - Validates foreign modules constrains.
      *
      * @api
      *
@@ -37,7 +43,7 @@ interface ComposerConstrainerFacadeInterface
 
     /**
      * Specification:
-     * - Updates core and foreign module constrains.
+     * - Updates foreign modules constrains.
      *
      * @api
      *

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/ExtendedModuleFinder/ExtendedModuleFinder.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/ExtendedModuleFinder/ExtendedModuleFinder.php
@@ -62,7 +62,7 @@ class ExtendedModuleFinder implements FinderInterface
             ->files()
             ->in($this->config->getSourceDirectory())
             ->filter($this->getFileFilter())
-            ->exclude(['Generated', 'Orm'])
+            ->exclude($this->config->getExcludedNameSpaces())
             ->name('*.php');
 
         return $finder;

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/ExtendedModuleFinder/ExtendedModuleFinder.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/ExtendedModuleFinder/ExtendedModuleFinder.php
@@ -62,7 +62,7 @@ class ExtendedModuleFinder implements FinderInterface
             ->files()
             ->in($this->config->getSourceDirectory())
             ->filter($this->getFileFilter())
-            ->exclude($this->config->getExcludedNameSpaces())
+            ->exclude($this->config->getExcludedNamespaces())
             ->name('*.php');
 
         return $finder;

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdk\Zed\ComposerConstrainer\Business\Finder\UsedForeignModuleFinder;
+
+use Closure;
+use Generated\Shared\Transfer\UsedModuleCollectionTransfer;
+use Generated\Shared\Transfer\UsedModuleTransfer;
+use ReflectionClass;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
+use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface;
+use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+class UsedForeignModuleFinder implements FinderInterface
+{
+    /**
+     * @var \SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig
+     */
+    protected $config;
+
+    /**
+     * @param \SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig $config
+     */
+    public function __construct(ComposerConstrainerConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return \Generated\Shared\Transfer\UsedModuleCollectionTransfer
+     */
+    public function find(): UsedModuleCollectionTransfer
+    {
+        $usedModuleCollectionTransfer = new UsedModuleCollectionTransfer();
+
+        if (!is_dir($this->config->getSourceDirectory())) {
+            return $usedModuleCollectionTransfer;
+        }
+
+        foreach ($this->createFinder() as $splFileInfo) {
+            $usedModuleCollectionTransfer = $this->addUsedForeignModules($usedModuleCollectionTransfer, $splFileInfo);
+        }
+
+        return $usedModuleCollectionTransfer;
+    }
+
+    /**
+     * @return \Symfony\Component\Finder\Finder|\Symfony\Component\Finder\SplFileInfo[]
+     */
+    protected function createFinder(): Finder
+    {
+        $finder = new Finder();
+        $finder
+            ->files()
+            ->in($this->config->getSourceDirectory())
+            ->filter($this->getFileFilter())
+            ->exclude(['Generated', 'Orm'])
+            ->name('*.php');
+
+        return $finder;
+    }
+
+    /**
+     * @return \Closure
+     */
+    protected function getFileFilter(): Closure
+    {
+        return function (SplFileInfo $fileInfo) {
+            $filePath = $fileInfo->getPathname();
+            if (preg_match('/src\/(.*?)\/(.*?)\/(.*?)Config.php|src\/(.*?)\/(.*?)\/(.*?)DependencyProvider.php/', $filePath)) {
+                return false;
+            }
+
+            return true;
+        };
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\UsedModuleCollectionTransfer $usedModuleCollectionTransfer
+     * @param \Symfony\Component\Finder\SplFileInfo $splFileInfo
+     *
+     * @return \Generated\Shared\Transfer\UsedModuleCollectionTransfer
+     */
+    protected function addUsedForeignModules(UsedModuleCollectionTransfer $usedModuleCollectionTransfer, SplFileInfo $splFileInfo): UsedModuleCollectionTransfer
+    {
+        $fileContent = $splFileInfo->getContents();
+        $coreNamespaces = $this->config->getCoreNamespaces();
+        $pattern = sprintf('/(?<organization>%s)\\\\(Client|Glue|Shared|Service|Yves|Zed)\\\\(?<module>\w*)\\\\/', implode('|', $coreNamespaces));
+
+        foreach ($this->getUsedClassesInFile($splFileInfo) as $extendedClassName) {
+            if (preg_match_all($pattern, $extendedClassName, $matches, PREG_SET_ORDER)) {
+                foreach ($matches as $match) {
+                    $usedModuleTransfer = new UsedModuleTransfer();
+                    $usedModuleTransfer
+                        ->setOrganization($match['organization'])
+                        ->setModule($match['module']);
+
+                    //$usedModuleCollectionTransfer->addUsedModule($usedModuleTransfer);
+                }
+            }
+        }
+
+        return $usedModuleCollectionTransfer;
+    }
+
+    /**
+     * @param \Symfony\Component\Finder\SplFileInfo $splFileInfo
+     *
+     * @return string[]
+     */
+    protected function getUsedClassesInFile(SplFileInfo $splFileInfo): array
+    {
+        $astLocator = (new BetterReflection())->astLocator();
+        $reflector = new ClassReflector(new SingleFileSourceLocator($splFileInfo->getPathname(), $astLocator));
+        $classes = $reflector->getAllClasses();
+        $extendedClasses = [];
+
+        /*
+        foreach ($classes as $class) {
+            $classNameFragments = explode('\\', $class->getName());
+            array_shift($classNameFragments);
+            $reflectionClass = new ReflectionClass($class->getName());
+            $extended = $reflectionClass->getParentClass();
+
+            if ($extended) {
+                $extendedClassNameFragments = explode('\\', $extended->getName());
+                array_shift($extendedClassNameFragments);
+
+                if ($classNameFragments === $extendedClassNameFragments) {
+                    $extendedClasses[] = $extended->getName();
+                }
+            }
+        }*/
+
+        return $extendedClasses;
+    }
+}

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
@@ -94,8 +94,9 @@ class UsedForeignModuleFinder implements FinderInterface
      *
      * @return \Generated\Shared\Transfer\UsedModuleCollectionTransfer
      */
-    protected function addUsedForeignModules(UsedModuleCollectionTransfer $usedModuleCollectionTransfer, SplFileInfo $splFileInfo): UsedModuleCollectionTransfer
-    {
+    protected function addUsedForeignModules(
+        UsedModuleCollectionTransfer $usedModuleCollectionTransfer,
+        SplFileInfo $splFileInfo): UsedModuleCollectionTransfer {
         $fileContent = $splFileInfo->getContents();
         foreach ($this->getUsedClassNamesInFile($fileContent) as $usedClassName) {
             if (!$this->isExcludedClass($usedClassName) && $this->isVendorClass($usedClassName)) {

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
@@ -116,7 +116,7 @@ class UsedForeignModuleFinder implements FinderInterface
     {
         $namespaces = array_merge(
             $this->config->getCoreNamespaces(),
-            $this->config->getExcludedNameSpaces(),
+            $this->config->getExcludedNamespaces(),
             $this->config->getProjectNamespaces()
         );
         $pattern = sprintf('/(%s)\\\\/', implode('|', $namespaces));
@@ -133,6 +133,10 @@ class UsedForeignModuleFinder implements FinderInterface
     {
         $classFilename = $this->getClassFileNameByClassName($className);
         $composerJsonData = $this->getComposerJsonDataByClassFilename($classFilename);
+        if (empty($composerJsonData)) {
+
+            return null;
+        }
         $packageName = explode('/', $composerJsonData['name']);
         $usedModuleTransfer = (new UsedModuleTransfer())
             ->setOrganization($packageName[0])
@@ -184,7 +188,7 @@ class UsedForeignModuleFinder implements FinderInterface
      *
      * @return string[]
      */
-    protected function getUsedClassesInFile(string $fileContent): array
+    protected function getUsedClassNamesInFile(string $fileContent): array
     {
         $pattern = '/^use (.*);/m';
         $usedClasses = [];

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
@@ -96,7 +96,8 @@ class UsedForeignModuleFinder implements FinderInterface
      */
     protected function addUsedForeignModules(
         UsedModuleCollectionTransfer $usedModuleCollectionTransfer,
-        SplFileInfo $splFileInfo): UsedModuleCollectionTransfer {
+        SplFileInfo $splFileInfo
+    ): UsedModuleCollectionTransfer {
         $fileContent = $splFileInfo->getContents();
         foreach ($this->getUsedClassNamesInFile($fileContent) as $usedClassName) {
             if (!$this->isExcludedClass($usedClassName) && $this->isVendorClass($usedClassName)) {
@@ -135,7 +136,6 @@ class UsedForeignModuleFinder implements FinderInterface
         $classFilename = $this->getClassFileNameByClassName($className);
         $composerJsonData = $this->getComposerJsonDataByClassFilename($classFilename);
         if (empty($composerJsonData)) {
-
             return null;
         }
         $packageName = explode('/', $composerJsonData['name']);

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
@@ -97,7 +97,7 @@ class UsedForeignModuleFinder implements FinderInterface
     protected function addUsedForeignModules(UsedModuleCollectionTransfer $usedModuleCollectionTransfer, SplFileInfo $splFileInfo): UsedModuleCollectionTransfer
     {
         $fileContent = $splFileInfo->getContents();
-        foreach ($this->getUsedClassesInFile($fileContent) as $usedClassName) {
+        foreach ($this->getUsedClassNamesInFile($fileContent) as $usedClassName) {
             if (!$this->isExcludedClass($usedClassName) && $this->isVendorClass($usedClassName)) {
                 $usedModuleTransfer = $this->getUsedModuleByClassName($usedClassName);
                 $usedModuleCollectionTransfer->addUsedModule($usedModuleTransfer);

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
@@ -120,7 +120,7 @@ class ComposerConstraintConsole extends Console
     {
         $composerConstraintCollectionTransfer = $this->getFacade()->updateConstraints();
 
-        if ($this->input->getOption(static::OPTION_WITH_FOREIGN) ) {
+        if ($this->input->getOption(static::OPTION_WITH_FOREIGN)) {
             $composerForeignConstraintCollectionTransfer = $this->getFacade()->updateForeignConstraints();
             $composerConstraintCollectionTransfer = $this->mergeComposerConstraintCollectionTransfers(
                 $composerConstraintCollectionTransfer,

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
@@ -85,10 +85,9 @@ class ComposerConstraintConsole extends Console
      * @return \Generated\Shared\Transfer\ComposerConstraintCollectionTransfer
      */
     protected function mergeComposerConstraintCollectionTransfers(
-        ComposerConstraintCollectionTransfer  $composerConstraintCollectionTransferA,
-        ComposerConstraintCollectionTransfer  $composerConstraintCollectionTransferB) :
-        ComposerConstraintCollectionTransfer {
-
+        ComposerConstraintCollectionTransfer $composerConstraintCollectionTransferA,
+        ComposerConstraintCollectionTransfer $composerConstraintCollectionTransferB
+    ): ComposerConstraintCollectionTransfer {
         foreach ($composerConstraintCollectionTransferB->getComposerConstraints() as $composerConstraint) {
             $composerConstraintCollectionTransferA->addComposerConstraint($composerConstraint);
         }
@@ -119,14 +118,14 @@ class ComposerConstraintConsole extends Console
      */
     protected function runUpdate(): int
     {
-        //$composerConstraintCollectionTransfer = $this->getFacade()->updateConstraints();
+        $composerConstraintCollectionTransfer = $this->getFacade()->updateConstraints();
 
         if ($this->input->getOption(static::OPTION_WITH_FOREIGN) ) {
             $composerForeignConstraintCollectionTransfer = $this->getFacade()->updateForeignConstraints();
-            //$composerConstraintCollectionTransfer = $this->mergeComposerConstraintCollectionTransfers(
-            //    $composerConstraintCollectionTransfer,
-            //    $composerForeignConstraintCollectionTransfer
-            //);
+            $composerConstraintCollectionTransfer = $this->mergeComposerConstraintCollectionTransfers(
+                $composerConstraintCollectionTransfer,
+                $composerForeignConstraintCollectionTransfer
+            );
         }
 
         if ($composerConstraintCollectionTransfer->getComposerConstraints()->count() === 0) {

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
@@ -32,7 +32,6 @@ class ComposerConstraintConsole extends Console
         $this
             ->setName(static::COMMAND_NAME)
             ->setDescription('Updates composer constraints in projects. When a module is extended on project level, this command will change ^ to ~ in the project\'s composer.json. This will make sure that a composer update will only pull patch versions of it for better backwards compatibility.');
-
         $this->addOption(static::OPTION_DRY_RUN, static::OPTION_DRY_RUN_SHORT, InputOption::VALUE_NONE, 'Use this option to validate your projects\' constraints.');
         $this->addOption(static::OPTION_FOREIGN, static::OPTION_FOREIGN_SHORT, InputOption::VALUE_NONE, 'Use this option to validate also foreign modules\' constraints.');
     }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
@@ -33,7 +33,7 @@ class ComposerConstraintConsole extends Console
             ->setName(static::COMMAND_NAME)
             ->setDescription('Updates composer constraints in projects. When a module is extended on project level, this command will change ^ to ~ in the project\'s composer.json. This will make sure that a composer update will only pull patch versions of it for better backwards compatibility.');
         $this->addOption(static::OPTION_DRY_RUN, static::OPTION_DRY_RUN_SHORT, InputOption::VALUE_NONE, 'Use this option to validate your projects\' constraints.');
-        $this->addOption(static::OPTION_FOREIGN, static::OPTION_FOREIGN_SHORT, InputOption::VALUE_NONE, 'Use this option to validate also foreign modules\' constraints.');
+        $this->addOption(static::OPTION_WITH_FOREIGN, static::OPTION_WITH_FOREIGN_SHORT, InputOption::VALUE_NONE, 'Use this option to validate also foreign modules\' constraints.');
     }
 
     /**
@@ -57,7 +57,7 @@ class ComposerConstraintConsole extends Console
     protected function runValidation(): int
     {
         $composerConstraintCollectionTransfer = $this->getFacade()->validateConstraints();
-        if ($this->input->getOption(static::OPTION_FOREIGN)) {
+        if ($this->input->getOption(static::OPTION_WITH_FOREIGN)) {
             $composerForeignConstraintCollectionTransfer = $this->getFacade()->validateForeignConstraints();
             $composerConstraintCollectionTransfer = $this->mergeComposerConstraintCollectionTransfers(
                 $composerConstraintCollectionTransfer,
@@ -89,12 +89,11 @@ class ComposerConstraintConsole extends Console
         ComposerConstraintCollectionTransfer  $composerConstraintCollectionTransferB) :
         ComposerConstraintCollectionTransfer {
 
-        return (new ComposerConstraintCollectionTransfer())->setComposerConstraints(
-            array_merge(
-                $composerConstraintCollectionTransferA->getComposerConstraints(),
-                $composerConstraintCollectionTransferB->getComposerConstraints()
-            )
-        );
+        foreach ($composerConstraintCollectionTransferB->getComposerConstraints() as $composerConstraint) {
+            $composerConstraintCollectionTransferA->addComposerConstraint($composerConstraint);
+        }
+
+        return $composerConstraintCollectionTransferA;
     }
 
     /**
@@ -120,14 +119,14 @@ class ComposerConstraintConsole extends Console
      */
     protected function runUpdate(): int
     {
-        $composerConstraintCollectionTransfer = $this->getFacade()->updateConstraints();
+        //$composerConstraintCollectionTransfer = $this->getFacade()->updateConstraints();
 
-        if ($this->input->getOption(static::OPTION_FOREIGN) ) {
+        if ($this->input->getOption(static::OPTION_WITH_FOREIGN) ) {
             $composerForeignConstraintCollectionTransfer = $this->getFacade()->updateForeignConstraints();
-            $composerConstraintCollectionTransfer = $this->mergeComposerConstraintCollectionTransfers(
-                $composerConstraintCollectionTransfer,
-                $composerForeignConstraintCollectionTransfer
-            );
+            //$composerConstraintCollectionTransfer = $this->mergeComposerConstraintCollectionTransfers(
+            //    $composerConstraintCollectionTransfer,
+            //    $composerForeignConstraintCollectionTransfer
+            //);
         }
 
         if ($composerConstraintCollectionTransfer->getComposerConstraints()->count() === 0) {

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
@@ -104,7 +104,6 @@ class ComposerConstraintConsole extends Console
             $this->output->writeln('<fg=green>No constraint issues found.</>');
         } else {
             $this->output->writeln(sprintf('<fg=green>%s constraint issues found and fixed.</>', $composerConstraintCollectionTransfer->getComposerConstraints()->count()));
-            $this->output->writeln(sprintf('<fg=green>%s constraint issues found and fixed.</>', $composerConstraintCollectionTransfer->getComposerConstraints()->count()));
         }
 
         return static::CODE_SUCCESS;

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
@@ -21,6 +21,8 @@ class ComposerConstraintConsole extends Console
     public const COMMAND_NAME = 'code:constraint:modules';
     public const OPTION_DRY_RUN = 'dry-run';
     public const OPTION_DRY_RUN_SHORT = 'd';
+    public const OPTION_FOREIGN = 'foreign';
+    public const OPTION_FOREIGN_SHORT = 'f';
 
     /**
      * @return void
@@ -32,6 +34,7 @@ class ComposerConstraintConsole extends Console
             ->setDescription('Updates composer constraints in projects. When a module is extended on project level, this command will change ^ to ~ in the project\'s composer.json. This will make sure that a composer update will only pull patch versions of it for better backwards compatibility.');
 
         $this->addOption(static::OPTION_DRY_RUN, static::OPTION_DRY_RUN_SHORT, InputOption::VALUE_NONE, 'Use this option to validate your projects\' constraints.');
+        $this->addOption(static::OPTION_FOREIGN, static::OPTION_FOREIGN_SHORT, InputOption::VALUE_NONE, 'Use this option to validate also foreign modules\' constraints.');
     }
 
     /**

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Communication/Console/ComposerConstraintConsole.php
@@ -56,7 +56,9 @@ class ComposerConstraintConsole extends Console
      */
     protected function runValidation(): int
     {
-        $composerConstraintCollectionTransfer = $this->getFacade()->validateConstraints();
+        $composerConstraintCollectionTransfer = $this->input->getOption(static::OPTION_FOREIGN) ?
+            $this->getFacade()->validateCoreAndForeignConstraints() :
+            $this->getFacade()->validateConstraints();
 
         if ($composerConstraintCollectionTransfer->getComposerConstraints()->count() === 0) {
             $this->output->writeln('<fg=green>No constraint issues found.</>');
@@ -94,11 +96,14 @@ class ComposerConstraintConsole extends Console
      */
     protected function runUpdate(): int
     {
-        $composerConstraintCollectionTransfer = $this->getFacade()->updateConstraints();
+        $composerConstraintCollectionTransfer = $this->input->getOption(static::OPTION_FOREIGN) ?
+            $this->getFacade()->updateCoreAndForeignConstraints() :
+            $this->getFacade()->updateConstraints();
 
         if ($composerConstraintCollectionTransfer->getComposerConstraints()->count() === 0) {
             $this->output->writeln('<fg=green>No constraint issues found.</>');
         } else {
+            $this->output->writeln(sprintf('<fg=green>%s constraint issues found and fixed.</>', $composerConstraintCollectionTransfer->getComposerConstraints()->count()));
             $this->output->writeln(sprintf('<fg=green>%s constraint issues found and fixed.</>', $composerConstraintCollectionTransfer->getComposerConstraints()->count()));
         }
 

--- a/src/SprykerSdk/Zed/ComposerConstrainer/ComposerConstrainerConfig.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/ComposerConstrainerConfig.php
@@ -47,6 +47,29 @@ class ComposerConstrainerConfig extends AbstractBundleConfig
     /**
      * @api
      *
+     * @return string[]
+     */
+    public function getProjectNamespaces(): array
+    {
+        return $this->get(ComposerConstrainerConstants::PROJECT_NAMESPACES);
+    }
+
+    /**
+     * @api
+     *
+     * @return string[]
+     */
+    public function getExcludedNamespaces()
+    {
+        return [
+            'Generated',
+            'Orm'
+        ];
+    }
+
+    /**
+     * @api
+     *
      * @return string
      */
     public function getVendorDirectory(): string

--- a/src/SprykerSdk/Zed/ComposerConstrainer/ComposerConstrainerConfig.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/ComposerConstrainerConfig.php
@@ -63,7 +63,7 @@ class ComposerConstrainerConfig extends AbstractBundleConfig
     {
         return [
             'Generated',
-            'Orm'
+            'Orm',
         ];
     }
 

--- a/src/SprykerSdk/Zed/ComposerConstrainer/ComposerConstrainerConfig.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/ComposerConstrainerConfig.php
@@ -59,7 +59,7 @@ class ComposerConstrainerConfig extends AbstractBundleConfig
      *
      * @return string[]
      */
-    public function getExcludedNamespaces()
+    public function getExcludedNamespaces(): array
     {
         return [
             'Generated',

--- a/src/SprykerSdk/Zed/ComposerConstrainer/ComposerConstrainerConfig.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/ComposerConstrainerConfig.php
@@ -43,4 +43,14 @@ class ComposerConstrainerConfig extends AbstractBundleConfig
     {
         return $this->get(ComposerConstrainerConstants::CORE_NAMESPACES);
     }
+
+    /**
+     * @api
+     *
+     * @return string
+     */
+    public function getVendorDirectory(): string
+    {
+        return $this->getProjectRootPath() . 'vendor/';
+    }
 }

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinderTest.php
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinderTest.php
@@ -10,7 +10,6 @@ namespace SprykerSdkTest\Zed\ComposerConstrainer\Business\Finder\UsedForeignModu
 use Codeception\Test\Unit;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson\ComposerJsonReader;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\UsedForeignModuleFinder\UsedForeignModuleFinder;
-use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
 
 /**
  * @group SprykerSdk
@@ -19,7 +18,7 @@ use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
  * @group Business
  * @group Finder
  * @group ExtendedModuleFinder
- * @group ExtendedModuleFinderTest
+ * @group ExtendedModuleFinderTes
  */
 class UsedForeignModuleFinderTest extends Unit
 {
@@ -59,6 +58,9 @@ class UsedForeignModuleFinderTest extends Unit
         $this->assertCount(0, $usedModuleTransferCollection->getUsedModules());
     }
 
+    /**
+     * @return void
+     */
     public function testFindSkipsConfigExtended(): void
     {
         $root = $this->tester->getVirtualDirectoryWhereModuleConfigIsExtended();
@@ -71,6 +73,9 @@ class UsedForeignModuleFinderTest extends Unit
         $this->assertCount(0, $usedModuleTransferCollection->getUsedModules());
     }
 
+    /**
+     * @return void
+     */
     public function testFindSkipsCoreModules(): void
     {
         // Arrange
@@ -107,12 +112,12 @@ class UsedForeignModuleFinderTest extends Unit
     */
     protected function getFinder(string $root): UsedForeignModuleFinder
     {
-        $composerConstrainerConfig = $this->tester->mockConfigMethod('getProjectRootPath', function () use ($root) {
+        $this->tester->mockConfigMethod('getProjectRootPath', function () use ($root) {
             return $root;
         });
 
         $composerConstrainerConfig = $this->tester->mockConfigMethod('getVendorDirectory', function () use ($root) {
-            return $root . 'vendor/';;
+            return $root . 'vendor/';
         });
 
         $composerJsonReader = new ComposerJsonReader($composerConstrainerConfig);

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinderTest.php
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdkTest\Zed\ComposerConstrainer\Business\Finder\UsedForeignModuleFinder;
+
+use Codeception\Test\Unit;
+use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson\ComposerJsonReader;
+use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\UsedForeignModuleFinder\UsedForeignModuleFinder;
+use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
+
+/**
+ * @group SprykerSdk
+ * @group Zed
+ * @group ComposerConstrainer
+ * @group Business
+ * @group Finder
+ * @group ExtendedModuleFinder
+ * @group ExtendedModuleFinderTest
+ */
+class UsedForeignModuleFinderTest extends Unit
+{
+    /**
+     * @var \SprykerSdkTest\Zed\ComposerConstrainer\ComposerConstrainerBusinessTester
+     */
+    protected $tester;
+
+    /**
+     * @return void
+     */
+    public function testFindReturnsEmptyUsedModuleTransferCollectionWhenDirectoryIsNotValid(): void
+    {
+        // Arrange
+        $usedForeignModuleFinder = $this->getFinder('$root/not/existing/directory');
+
+        // Act
+        $usedModuleTransferCollection = $usedForeignModuleFinder->find();
+
+        // Assert
+        $this->assertCount(0, $usedModuleTransferCollection->getUsedModules());
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindSkipsModuleDependencyProvider(): void
+    {
+        // Arrange
+        $root = $this->tester->getVirtualDirectoryWhereModuleDependencyProviderIsExtended();
+        $usedForeignModuleFinder = $this->getFinder($root);
+
+        // Act
+        $usedModuleTransferCollection = $usedForeignModuleFinder->find();
+
+        // Assert
+        $this->assertCount(0, $usedModuleTransferCollection->getUsedModules());
+    }
+
+    public function testFindSkipsConfigExtended(): void
+    {
+        $root = $this->tester->getVirtualDirectoryWhereModuleConfigIsExtended();
+        $usedForeignModuleFinder = $this->getFinder($root);
+
+        // Act
+        $usedModuleTransferCollection = $usedForeignModuleFinder->find();
+
+        // Assert
+        $this->assertCount(0, $usedModuleTransferCollection->getUsedModules());
+    }
+
+    public function testFindSkipsCoreModules(): void
+    {
+        // Arrange
+        $root = $this->tester->getVirtualDirectoryWhereModuleClassIsExtended();
+        $usedForeignModuleFinder = $this->getFinder($root);
+
+        // Act
+        $usedModuleTransferCollection = $usedForeignModuleFinder->find();
+
+        // Assert
+        $this->assertCount(0, $usedModuleTransferCollection->getUsedModules());
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindFindsUsedForeignModule(): void
+    {
+        // Arrange
+        $root = $this->tester->getVirtualDirectoryWhereForeignModuleIsUsed();
+        $usedForeignModuleFinder = $this->getFinder($root);
+
+        // Act
+        $usedModuleTransferCollection = $usedForeignModuleFinder->find();
+
+        // Assert
+        $this->assertCount(1, $usedModuleTransferCollection->getUsedModules());
+    }
+
+    /**
+     * @param string $root
+     *
+     * @return UsedForeignModuleFinder
+    */
+    protected function getFinder(string $root): UsedForeignModuleFinder
+    {
+        $composerConstrainerConfig = $this->tester->mockConfigMethod('getProjectRootPath', function () use ($root) {
+            return $root;
+        });
+
+        $composerConstrainerConfig = $this->tester->mockConfigMethod('getVendorDirectory', function () use ($root) {
+            return $root . 'vendor/';;
+        });
+
+        $composerJsonReader = new ComposerJsonReader($composerConstrainerConfig);
+
+        return  new UsedForeignModuleFinder($composerConstrainerConfig, $composerJsonReader);
+    }
+}

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinderTest.php
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinderTest.php
@@ -108,8 +108,8 @@ class UsedForeignModuleFinderTest extends Unit
     /**
      * @param string $root
      *
-     * @return UsedForeignModuleFinder
-    */
+     * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Finder\UsedForeignModuleFinder\UsedForeignModuleFinder
+     */
     protected function getFinder(string $root): UsedForeignModuleFinder
     {
         $this->tester->mockConfigMethod('getProjectRootPath', function () use ($root) {
@@ -122,6 +122,6 @@ class UsedForeignModuleFinderTest extends Unit
 
         $composerJsonReader = new ComposerJsonReader($composerConstrainerConfig);
 
-        return  new UsedForeignModuleFinder($composerConstrainerConfig, $composerJsonReader);
+        return new UsedForeignModuleFinder($composerConstrainerConfig, $composerJsonReader);
     }
 }

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/_support/ComposerConstrainerBusinessTester.php
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/_support/ComposerConstrainerBusinessTester.php
@@ -73,7 +73,6 @@ class ComposerConstrainerBusinessTester extends Actor
             'vendor' => [
                 'foreign' => [
                     'bar' => [
-                        //'BarClass.php' => $this->buildFileContent('Foreign', 'BarClass', '\Foo\\'),
                         'composer.json' => $this->buildPackageComposerJsonFile('foreign', 'bar')
                     ]
                 ]

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/_support/ComposerConstrainerBusinessTester.php
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/_support/ComposerConstrainerBusinessTester.php
@@ -74,9 +74,9 @@ class ComposerConstrainerBusinessTester extends Actor
                 'foreign' => [
                     'bar' => [
                         'composer.json' => $this->buildPackageComposerJsonFile('foreign', 'bar')
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
 
         $virtualDirectory = $this->getVirtualDirectory($structure);
@@ -88,14 +88,13 @@ class ComposerConstrainerBusinessTester extends Actor
         return $virtualDirectory;
     }
 
-
     /**
      * @param string $vendorName
-     * @param $namespace
+     * @param string $namespace
      *
      * @return string
      */
-    protected function buildPackageComposerJsonFile(string $vendorName, $namespace): string
+    protected function buildPackageComposerJsonFile(string $vendorName, string $namespace): string
     {
         $fileContent = <<<CODE
 {
@@ -164,6 +163,8 @@ CODE;
      * @param string $organization
      * @param string $className
      * @param string $subNamespace
+     *
+     * @return void
      */
     protected function includeUsedClass(
         string $path,
@@ -189,11 +190,15 @@ CODE;
     /**
      * @param string $organization
      * @param string $className
+     * @param string $subNamespace
      *
      * @return string
      */
-    protected function buildFileContent(string $organization, string $className, string $subNamespace = '\Zed\Module\\'): string
-    {
+    protected function buildFileContent(
+        string $organization,
+        string $className,
+        string $subNamespace = '\Zed\Module\\'
+    ): string {
         $fileContent = <<<CODE
 <?php
 namespace Project\Zed\Module;

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/_support/ComposerConstrainerBusinessTester.php
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/_support/ComposerConstrainerBusinessTester.php
@@ -73,7 +73,7 @@ class ComposerConstrainerBusinessTester extends Actor
             'vendor' => [
                 'foreign' => [
                     'bar' => [
-                        'composer.json' => $this->buildPackageComposerJsonFile('foreign', 'bar')
+                        'composer.json' => $this->buildPackageComposerJsonFile('foreign', 'bar'),
                     ],
                 ],
             ],


### PR DESCRIPTION
Ticket: [TE-8265](https://spryker.atlassian.net/browse/TE-8265)
Improvements 
- Developer(s): @qlmmlp 

- Ticket: https://spryker.atlassian.net/browse/TE-5835

- Academy PR: TBD

- Release Group: https://release.spryker.com/release-groups/view/3194

- PR Overview: https://release.spryker.com/release/pull-request-sdk/ComposerConstrainer/13

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ComposerConstrainer  | patch (currently 0.x)  |                       |


-----------------------------------------

#### Module ComposerConstrainer

##### Change log

Improvements

* Introduced `ComposerConstrainerConstants::PROJECT_NAMESPACES` used to configure a list of project namespaces.
* Introduced `ComposerConstrainerFacade::updateForeignConstraints()` to update foreign modules constraints. 
* Introduced `ComposerConstrainerFacade::validateForeignConstraints()` to validate foreign modules constraints.
* Added support for `--with-foreign` (`-w`) boolean option in `ComposerConstraintConsole` for validating or updating foreign package constraints. 
* Introduced `ComposerConstrainerConfig::getProjectNamespaces()` which provides a list of project namespaces.
* Introduced `ComposerConstrainerConfig::getExcludedNamespaces()` which provides a list of namespaces meant to be skipped during the validation/update.
 * Introduced `ComposerConstrainerConfig::getVendorDirectory()`.
