### PR TITLE
Improve composer.json generation. Add tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Check PHP for syntax errors
         run: find ./src -path src -prune -o -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
 
+      - name: Run tests
+        run: codeception run
+
       - name: PHPStan checks
         run: composer stan
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,4 @@ jobs:
         run: find ./src -path src -prune -o -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
 
       - name: Validate prefer lowest
-        run: vendor/bin/validate-prefer-lowest
+        run: vendor/bin/validate-prefer-lowest -m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Check PHP for syntax errors
         run: find ./src -path src -prune -o -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
 
-      - name: CodeStyle checks
-        run: composer cs-check
-
       - name: PHPStan checks
         run: composer stan
+
+      - name: CodeStyle checks
+        run: composer cs-check
 
   prefer-lowest:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: find ./src -path src -prune -o -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
 
       - name: Run tests
-        run: codeception run
+        run: composer test
 
       - name: PHPStan checks
         run: composer stan

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ src/*/Zed/*/Persistence/Propel/Base/*
 src/*/Zed/*/Persistence/Propel/Map/*
 
 # tests
+src/Generated
+src/Spryker
 tests/**/_generated/
 tests/_output/*
 !tests/_output/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,8 @@ src/*/Zed/*/Persistence/Propel/Base/*
 src/*/Zed/*/Persistence/Propel/Map/*
 
 # tests
-src/Generated
-src/Spryker
+tests/app/src/Generated/
+tests/app/src/Spryker/
 tests/**/_generated/
 tests/_output/*
 !tests/_output/.gitkeep

--- a/codeception.yml
+++ b/codeception.yml
@@ -18,3 +18,4 @@ coverage:
     whitelist:
         include:
             - 'src/*'
+bootstrap: bootstrap.php

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
         "spryker/symfony": "^3.2.2"
     },
     "require-dev": {
+        "codeception/module-asserts": "^1.3",
+        "ergebnis/json-printer": "^3.1",
         "phpstan/phpstan": "^0.12.0",
         "spryker/code-sniffer": "*",
         "spryker/console": "*",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "scripts": {
         "cs-check": "phpcs -p -s --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml src/ tests/",
         "cs-fix": "phpcbf -p --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml src/ tests/",
-        "stan": "vendor/bin/phpstan analyse"
+        "stan": "vendor/bin/phpstan analyse",
+        "test": "vendor/bin/codecept run"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "cs-check": "phpcs -p -s --ignore=/src/Generated/ --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml src/ tests/",
-        "cs-fix": "phpcbf -p --ignore=/src/Generated/ --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml src/ tests/",
+        "cs-check": "phpcs -p -s --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml --ignore=/tests/app/ src/ tests/",
+        "cs-fix": "phpcbf -p --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml --ignore=/tests/app/ src/ tests/",
         "stan": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/codecept run"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "cs-check": "phpcs -p -s --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml src/ tests/",
-        "cs-fix": "phpcbf -p --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml src/ tests/",
+        "cs-check": "phpcs -p -s --ignore=/src/Generated/ --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml src/ tests/",
+        "cs-fix": "phpcbf -p --ignore=/src/Generated/ --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml src/ tests/",
         "stan": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/codecept run"
     },

--- a/config/Shared/stores.php
+++ b/config/Shared/stores.php
@@ -1,0 +1,62 @@
+<?php
+
+$stores = [];
+
+$stores['DE'] = [
+    // different contexts
+    'contexts' => [
+        // shared settings for all contexts
+        '*' => [
+            'timezone' => 'Europe/Berlin',
+            'dateFormat' => [
+                // short date (01.02.12)
+                'short' => 'd/m/Y',
+                // medium Date (01. Feb 2012)
+                'medium' => 'd. M Y',
+                // date formatted as described in RFC 2822
+                'rfc' => 'r',
+                'datetime' => 'Y-m-d H:i:s',
+            ],
+        ],
+        // settings for contexts (overwrite shared)
+        'yves' => [],
+        'zed' => [
+            'dateFormat' => [
+                // short date (2012-12-28)
+                'short' => 'Y-m-d',
+            ],
+        ],
+    ],
+    'locales' => [
+        // first entry is default
+        'en' => 'en_US',
+        'de' => 'de_DE',
+    ],
+    // first entry is default
+    'countries' => ['DE', 'AT', 'NO', 'CH', 'ES', 'GB'],
+    // internal and shop
+    'currencyIsoCode' => 'EUR',
+    'currencyIsoCodes' => ['EUR', 'CHF'],
+    'queuePools' => [
+        'synchronizationPool' => [
+            'AT-connection',
+            'DE-connection',
+        ],
+    ],
+    'storesWithSharedPersistence' => ['AT'],
+];
+
+$stores['AT'] = [
+        'storesWithSharedPersistence' => ['DE'],
+    ] + $stores['DE'];
+
+$stores['US'] = [
+        'queuePools' => [
+            'synchronizationPool' => [
+                'US-connection',
+            ],
+        ],
+        'storesWithSharedPersistence' => [],
+    ] + $stores['DE'];
+
+return $stores;

--- a/dependency.json
+++ b/dependency.json
@@ -1,0 +1,6 @@
+{
+    "include-dev": {
+        "codeception/module-asserts": "A Codeception module containing various assertions.",
+        "ergebnis/json-printer": "Optional, since this covers a non standard case for projects."
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 8
     paths:
         - src/
     excludes_analyse:
@@ -11,4 +11,3 @@ parameters:
     checkMissingIterableValueType: false
 
     ignoreErrors:
-        - '#Method Generated\\Shared\\Transfer\\.+Transfer::.+\(\) should return array but return statement is missing#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,13 @@ parameters:
     level: 1
     paths:
         - src/
+    excludes_analyse:
+
+    bootstrapFiles:
+        - tests/bootstrap.php
+
+    treatPhpDocTypesAsCertain: false
+    checkMissingIterableValueType: false
 
     ignoreErrors:
+        - '#Method Generated\\Shared\\Transfer\\.+Transfer::.+\(\) should return array but return statement is missing#'

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonReader.php
@@ -7,6 +7,7 @@
 
 namespace SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson;
 
+use RuntimeException;
 use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
 
 class ComposerJsonReader implements ComposerJsonReaderInterface
@@ -37,15 +38,22 @@ class ComposerJsonReader implements ComposerJsonReaderInterface
     /**
      * @param string $filePath
      *
+     * @throws \RuntimeException
+     *
      * @return array
      */
     public function readFromFilePath(string $filePath): array
     {
-        $composerJsonFileName = $filePath . static::COMPOSER_JSON_FILENAME;
-        if (!file_exists($composerJsonFileName)) {
+        $path = $filePath . static::COMPOSER_JSON_FILENAME;
+        if (!file_exists($path)) {
             return [];
         }
 
-        return json_decode(file_get_contents($composerJsonFileName), true);
+        $content = file_get_contents($path);
+        if ($content === false) {
+            throw new RuntimeException('Cannot read content: ' . $path);
+        }
+
+        return json_decode($content, true);
     }
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonWriter.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonWriter.php
@@ -31,13 +31,11 @@ class ComposerJsonWriter implements ComposerJsonWriterInterface
     /**
      * @param array $composerJsonArray
      *
-     * @throws \RuntimeException
-     *
      * @return bool
      */
     public function write(array $composerJsonArray): bool
     {
-        $encodedJson = json_encode($composerJsonArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $encodedJson = json_encode($composerJsonArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
 
         $indentation = static::INDENTATION_DEFAULT;
         $composerJsonFileName = $this->config->getProjectRootPath() . 'composer.json';
@@ -45,12 +43,7 @@ class ComposerJsonWriter implements ComposerJsonWriterInterface
             $indentation = $this->autoDetectIndentation($composerJsonFileName);
         }
         if ($indentation !== static::INDENTATION_DEFAULT) {
-            if (!class_exists(Printer::class)) {
-                throw new RuntimeException(
-                    sprintf('Non default 4 space indentation requires package `%s` installed.', 'ergebnis/json-printer')
-                );
-            }
-            $encodedJson = (new Printer())->print($encodedJson, str_repeat(' ', $indentation));
+            $encodedJson = $this->adjustIndentation($encodedJson, $indentation);
         }
 
         return (bool)file_put_contents($composerJsonFileName, $encodedJson);
@@ -76,5 +69,24 @@ class ComposerJsonWriter implements ComposerJsonWriterInterface
         }
 
         return strlen($matches[1]);
+    }
+
+    /**
+     * @param string $encodedJson
+     * @param int $indentation
+     *
+     * @throws \RuntimeException
+     *
+     * @return string
+     */
+    protected function adjustIndentation(string $encodedJson, int $indentation): string
+    {
+        if (!class_exists(Printer::class)) {
+            throw new RuntimeException(
+                sprintf('Non default 4 space indentation requires package `%s` installed.', 'ergebnis/json-printer')
+            );
+        }
+
+        return (new Printer())->print($encodedJson, str_repeat(' ', $indentation)) . PHP_EOL;
     }
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonWriter.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonWriter.php
@@ -31,6 +31,8 @@ class ComposerJsonWriter implements ComposerJsonWriterInterface
     /**
      * @param array $composerJsonArray
      *
+     * @throws \RuntimeException
+     *
      * @return bool
      */
     public function write(array $composerJsonArray): bool

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerLock/ComposerLockReader.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Composer/ComposerLock/ComposerLockReader.php
@@ -7,6 +7,7 @@
 
 namespace SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerLock;
 
+use RuntimeException;
 use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
 
 class ComposerLockReader implements ComposerLockReaderInterface
@@ -25,10 +26,22 @@ class ComposerLockReader implements ComposerLockReaderInterface
     }
 
     /**
+     * @throws \RuntimeException
+     *
      * @return array
      */
     public function read(): array
     {
-        return json_decode(file_get_contents($this->config->getProjectRootPath() . 'composer.lock'), true);
+        $path = $this->config->getProjectRootPath() . 'composer.lock';
+        if (!file_exists($path)) {
+            return [];
+        }
+
+        $content = file_get_contents($path);
+        if ($content === false) {
+            throw new RuntimeException('Cannot read content: ' . $path);
+        }
+
+        return json_decode($content, true);
     }
 }

--- a/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
+++ b/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/UsedForeignModuleFinder/UsedForeignModuleFinder.php
@@ -11,6 +11,7 @@ use Closure;
 use Generated\Shared\Transfer\UsedModuleCollectionTransfer;
 use Generated\Shared\Transfer\UsedModuleTransfer;
 use ReflectionClass;
+use RuntimeException;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson\ComposerJsonReaderInterface;
 use SprykerSdk\Zed\ComposerConstrainer\Business\Finder\FinderInterface;
 use SprykerSdk\Zed\ComposerConstrainer\ComposerConstrainerConfig;
@@ -102,6 +103,9 @@ class UsedForeignModuleFinder implements FinderInterface
         foreach ($this->getUsedClassNamesInFile($fileContent) as $usedClassName) {
             if (!$this->isExcludedClass($usedClassName) && $this->isVendorClass($usedClassName)) {
                 $usedModuleTransfer = $this->getUsedModuleByClassName($usedClassName);
+                if (!$usedModuleTransfer) {
+                    continue;
+                }
                 $usedModuleCollectionTransfer->addUsedModule($usedModuleTransfer);
             }
         }
@@ -127,6 +131,8 @@ class UsedForeignModuleFinder implements FinderInterface
     }
 
     /**
+     * @phpstan-param class-string $className
+     *
      * @param string $className
      *
      * @return \Generated\Shared\Transfer\UsedModuleTransfer|null
@@ -162,6 +168,8 @@ class UsedForeignModuleFinder implements FinderInterface
     }
 
     /**
+     * @phpstan-param class-string $className
+     *
      * @param string $className
      *
      * @return bool
@@ -175,16 +183,27 @@ class UsedForeignModuleFinder implements FinderInterface
     }
 
     /**
+     * @phpstan-param class-string $className
+     *
      * @param string $className
+     *
+     * @throws \RuntimeException
      *
      * @return string
      */
     protected function getClassFileNameByClassName(string $className): string
     {
-        return (new ReflectionClass($className))->getFileName();
+        $fileName = (new ReflectionClass($className))->getFileName();
+        if ($fileName === false) {
+            throw new RuntimeException('Cannot parse file name from ' . $className);
+        }
+
+        return $fileName;
     }
 
     /**
+     * @phpstan-return class-string[]
+     *
      * @param string $fileContent
      *
      * @return string[]
@@ -195,7 +214,9 @@ class UsedForeignModuleFinder implements FinderInterface
         $usedClasses = [];
         if (preg_match_all($pattern, $fileContent, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
-                $usedClasses[] = explode(' ', $match[1])[0];
+                /** @phpstan-var class-string $class */
+                $class = explode(' ', $match[1])[0];
+                $usedClasses[] = $class;
             }
         }
 

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonWriterTest.php
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonWriterTest.php
@@ -51,7 +51,7 @@ class ComposerJsonWriterTest extends Unit
 
         $path = dirname(__DIR__, 6) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR;
         $file = $path . 'composer4space.json';
-        $this->assertStringEqualsFile($file, $content . PHP_EOL);
+        $this->assertStringEqualsFile($file, $content);
     }
 
     /**
@@ -82,7 +82,7 @@ class ComposerJsonWriterTest extends Unit
 
         $content = file_get_contents($root . 'composer.json');
 
-        $this->assertStringEqualsFile($file, $content . PHP_EOL);
+        $this->assertStringEqualsFile($file, $content);
     }
 
     /**

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonWriterTest.php
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/Business/Composer/ComposerJson/ComposerJsonWriterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdkTest\Zed\ComposerConstrainer\Business\Composer\ComposerJson;
+
+use Codeception\Test\Unit;
+use SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson\ComposerJsonWriter;
+
+/**
+ * @group SprykerSdk
+ * @group Zed
+ * @group ComposerConstrainer
+ * @group Business
+ * @group ComposerJsonWriterTest
+ */
+class ComposerJsonWriterTest extends Unit
+{
+    /**
+     * @var \SprykerSdkTest\Zed\ComposerConstrainer\ComposerConstrainerBusinessTester
+     */
+    protected $tester;
+
+    /**
+     * @return void
+     */
+    public function testWriteDefaultIndentation(): void
+    {
+        // Arrange
+        $root = $this->tester->getVirtualDirectoryWhereModuleDependencyProviderIsExtended();
+        $composerJsonWriter = $this->getWriter($root);
+
+        $array = [
+            'name' => 'foo/bar',
+            'require' => [
+                'php' => '^7.4',
+            ],
+        ];
+
+        // Act
+        $result = $composerJsonWriter->write($array);
+
+        // Assert
+        $this->assertTrue($result);
+
+        $path = 'composer.json';
+        $content = $this->tester->getVirtualDirectoryFileContent($path);
+
+        $path = dirname(__DIR__, 6) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR;
+        $file = $path . 'composer4space.json';
+        $this->assertStringEqualsFile($file, $content . PHP_EOL);
+    }
+
+    /**
+     * @return void
+     */
+    public function testWriteTwoSpaceIndentation(): void
+    {
+        // Arrange
+        $path = dirname(__DIR__, 6) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR;
+        $file = $path . 'composer2space.json';
+
+        $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR;
+        copy($file, $root . 'composer.json');
+        $composerJsonWriter = $this->getWriter($root);
+
+        $array = [
+            'name' => 'foo/bar',
+            'require' => [
+                'php' => '^7.4',
+            ],
+        ];
+
+        // Act
+        $result = $composerJsonWriter->write($array);
+
+        // Assert
+        $this->assertTrue($result);
+
+        $content = file_get_contents($root . 'composer.json');
+
+        $this->assertStringEqualsFile($file, $content . PHP_EOL);
+    }
+
+    /**
+     * @param string $root
+     *
+     * @return \SprykerSdk\Zed\ComposerConstrainer\Business\Composer\ComposerJson\ComposerJsonWriter
+     */
+    protected function getWriter(string $root): ComposerJsonWriter
+    {
+        $this->tester->mockConfigMethod('getProjectRootPath', function () use ($root) {
+            return $root;
+        });
+
+        $composerConstrainerConfig = $this->tester->mockConfigMethod('getVendorDirectory', function () use ($root) {
+            return $root . 'vendor/';
+        });
+
+        return new ComposerJsonWriter($composerConstrainerConfig);
+    }
+}

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/codeception.yml
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/codeception.yml
@@ -22,10 +22,11 @@ suites:
                 - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
                       coreNamespaces:
                           - Spryker
-                          - SprykerShop
                           - SprykerSdk
                 - \SprykerTest\Shared\Transfer\Helper\TransferGenerateHelper:
                       isolated: true
+                      schemaDirectories:
+                          - ../../src/*/Shared/*/Transfer/
                 - \SprykerTest\Shared\Testify\Helper\DependencyHelper
                 - \SprykerTest\Zed\Console\Helper\ConsoleHelper
                 - \SprykerTest\Zed\Testify\Helper\BusinessHelper
@@ -40,7 +41,6 @@ suites:
                 - \SprykerTest\Shared\Testify\Helper\ConfigHelper
                 - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
                       coreNamespaces:
-                          - SprykerShop
                           - Spryker
                           - SprykerSdk
                 - \SprykerTest\Shared\Transfer\Helper\TransferGenerateHelper:

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/codeception.yml
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/codeception.yml
@@ -24,6 +24,8 @@ suites:
                           - SprykerShop
                           - Spryker
                           - SprykerSdk
+                - \SprykerTest\Shared\Transfer\Helper\TransferGenerateHelper:
+                      isolated: true
                 - \SprykerTest\Shared\Testify\Helper\DependencyHelper
                 - \SprykerTest\Zed\Console\Helper\ConsoleHelper
                 - \SprykerTest\Zed\Testify\Helper\BusinessHelper
@@ -41,6 +43,8 @@ suites:
                           - SprykerShop
                           - Spryker
                           - SprykerSdk
+                - \SprykerTest\Shared\Transfer\Helper\TransferGenerateHelper:
+                    isolated: true
                 - \SprykerTest\Shared\Testify\Helper\DependencyHelper
                 - \SprykerTest\Zed\Testify\Helper\BusinessHelper
                 - \SprykerTest\Shared\Testify\Helper\VirtualFilesystemHelper

--- a/tests/SprykerSdkTest/Zed/ComposerConstrainer/codeception.yml
+++ b/tests/SprykerSdkTest/Zed/ComposerConstrainer/codeception.yml
@@ -21,8 +21,8 @@ suites:
                 - \SprykerTest\Shared\Testify\Helper\ConfigHelper
                 - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
                       coreNamespaces:
-                          - SprykerShop
                           - Spryker
+                          - SprykerShop
                           - SprykerSdk
                 - \SprykerTest\Shared\Transfer\Helper\TransferGenerateHelper:
                       isolated: true

--- a/tests/_files/composer2space.json
+++ b/tests/_files/composer2space.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo/bar",
+  "require": {
+    "php": "^7.4"
+  }
+}

--- a/tests/_files/composer4space.json
+++ b/tests/_files/composer4space.json
@@ -1,0 +1,6 @@
+{
+    "name": "foo/bar",
+    "require": {
+        "php": "^7.4"
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,23 @@
 <?php
 
-define('APPLICATION_ROOT_DIR', sys_get_temp_dir());
+define('APPLICATION_ROOT_DIR', __DIR__ . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR);
+define('APPLICATION_STORE', 'DE');
+
+spl_autoload_register(function ($className) {
+    if (strrpos($className, 'Transfer') === false) {
+        return false;
+    }
+
+    $classNameParts = explode('\\', $className);
+
+    $transferFileName = implode(DIRECTORY_SEPARATOR, $classNameParts) . '.php';
+    $transferFilePath = APPLICATION_ROOT_DIR . 'src' . DIRECTORY_SEPARATOR . $transferFileName;
+
+    if (!file_exists($transferFilePath)) {
+        return false;
+    }
+
+    require_once $transferFilePath;
+
+    return true;
+});

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+define('APPLICATION_ROOT_DIR', sys_get_temp_dir());

--- a/tests/config/Shared/stores.php
+++ b/tests/config/Shared/stores.php
@@ -46,17 +46,4 @@ $stores['DE'] = [
     'storesWithSharedPersistence' => ['AT'],
 ];
 
-$stores['AT'] = [
-        'storesWithSharedPersistence' => ['DE'],
-    ] + $stores['DE'];
-
-$stores['US'] = [
-        'queuePools' => [
-            'synchronizationPool' => [
-                'US-connection',
-            ],
-        ],
-        'storesWithSharedPersistence' => [],
-    ] + $stores['DE'];
-
 return $stores;


### PR DESCRIPTION
Generated files must have newline at the end.

Release will happen together with https://spryker.atlassian.net/browse/TE-9771 epic

TODO

- [x] Fix codeception/module-asserts to not throw error on suite nonsplit dependency check