### PR TITLE
Move phpstan/phpstan from dev-dependencies to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "proprietary",
     "require": {
         "php": ">=7.4",
+        "phpstan/phpstan": "^1.2.0",
         "spryker/kernel": "^3.33.0",
         "spryker/laminas": "^1.0.0",
         "spryker/symfony": "^3.2.2",
@@ -13,7 +14,6 @@
     "require-dev": {
         "codeception/module-asserts": "^1.3",
         "ergebnis/json-printer": "^3.1",
-        "phpstan/phpstan": "^1.2.0",
         "spryker/code-sniffer": "*",
         "spryker/console": "*",
         "spryker/testify": "^3.15.0"


### PR DESCRIPTION
PHPStan is used in [ExtendedModuleFinder.php](https://github.com/spryker-sdk/composer-constrainer/blob/867437d857bb9b3fc36cf1ba6739fbbbc2afc5a4/src/SprykerSdk/Zed/ComposerConstrainer/Business/Finder/ExtendedModuleFinder/ExtendedModuleFinder.php#L13C47-L13C47). However, `phpstan/phpstan` is only a dev dependency. If your project does not have PHPStan installed (for whatever reason), this package crashes.