### PR TITLE
Re-add ondrejmirtes/better-reflection to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "proprietary",
     "require": {
         "php": ">=7.4",
+        "ondrejmirtes/better-reflection": "^4.3 || ^5.0 || ^6.0",
         "spryker/kernel": "^3.33.0",
         "spryker/laminas": "^1.0.0",
         "spryker/symfony": "^3.2.2",

--- a/dependency.json
+++ b/dependency.json
@@ -1,6 +1,7 @@
 {
     "include": {
-        "spryker/transfer": "Required for get*OrFail()."
+        "spryker/transfer": "Required for get*OrFail().",
+        "ondrejmirtes/better-reflection": "Provides reflection wrapper used for code analysis."
     },
     "exclude": {
         "spryker/testify": "Only needed for require-dev."


### PR DESCRIPTION
This solves the issue described in https://github.com/spryker-sdk/composer-constrainer/pull/28, while taking a better approach.  
It basically reverts https://github.com/spryker-sdk/composer-constrainer/pull/26, while allowing for different versions of [`ondrejmirtes/better-reflection`](https://github.com/ondrejmirtes/BetterReflection).